### PR TITLE
Name and label updates for admin1

### DIFF
--- a/data/856/825/75/85682575.geojson
+++ b/data/856/825/75/85682575.geojson
@@ -10,8 +10,14 @@
     "geom:latitude":55.356916,
     "geom:longitude":9.44873,
     "iso:country":"DK",
+    "label:dan_x_preferred_longname":[
+        "Region Syddanmark"
+    ],
+    "label:dan_x_preferred_placetype":[
+        "region"
+    ],
     "label:eng_x_preferred_longname":[
-        "Syddanmark Region"
+        "Region of Southern Denmark"
     ],
     "label:eng_x_preferred_placetype":[
         "region"
@@ -64,6 +70,9 @@
         "Syddanmark"
     ],
     "name:dan_x_preferred":[
+        "Syddanmark"
+    ],
+    "name:dan_x_variant":[
         "Region Syddanmark"
     ],
     "name:dut_x_preferred":[
@@ -73,11 +82,12 @@
         "\u03a0\u03b5\u03c1\u03b9\u03c6\u03ad\u03c1\u03b5\u03b9\u03b1 \u039d\u03cc\u03c4\u03b9\u03b1\u03c2 \u0394\u03b1\u03bd\u03af\u03b1\u03c2"
     ],
     "name:eng_x_preferred":[
-        "Syddanmark"
+        "Southern"
     ],
     "name:eng_x_variant":[
         "Region South Denmark",
         "South Denmark",
+        "Syddanmark",
         "Region of Southern Denmark"
     ],
     "name:epo_x_preferred":[
@@ -387,11 +397,10 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1553550703,
-    "wof:name":"Syddanmark",
+    "wof:lastmodified":1560375915,
+    "wof:name":"Southern",
     "wof:parent_id":85633121,
     "wof:placetype":"region",
-    "wof:placetype_alt":[],
     "wof:placetype_local":"region",
     "wof:population":1183751,
     "wof:population_rank":12,

--- a/data/856/825/81/85682581.geojson
+++ b/data/856/825/81/85682581.geojson
@@ -10,8 +10,14 @@
     "geom:latitude":55.690155,
     "geom:longitude":12.895162,
     "iso:country":"DK",
+    "label:dan_x_preferred_longname":[
+        "Region Hovedstaden"
+    ],
+    "label:dan_x_preferred_placetype":[
+        "region"
+    ],
     "label:eng_x_preferred_longname":[
-        "Hovedstaden Region"
+        "Capital Region"
     ],
     "label:eng_x_preferred_placetype":[
         "region"
@@ -64,20 +70,20 @@
         "Hovedstaden"
     ],
     "name:dan_x_preferred":[
-        "Region Hovedstaden"
+        "Hovedstaden"
     ],
     "name:dan_x_variant":[
-        "Hovedstaden"
+        "Region Hovedstaden"
     ],
     "name:dut_x_preferred":[
         "Hoofdstad"
     ],
     "name:eng_x_preferred":[
-        "Hovedstaden"
+        "Capital"
     ],
     "name:eng_x_variant":[
         "Capital Region",
-        "Capital",
+        "Hovedstaden",
         "Capital Region of Denmark"
     ],
     "name:epo_x_preferred":[
@@ -362,11 +368,10 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1553550705,
-    "wof:name":"Hovedstaden",
+    "wof:lastmodified":1560375925,
+    "wof:name":"Capital",
     "wof:parent_id":85633121,
     "wof:placetype":"region",
-    "wof:placetype_alt":[],
     "wof:placetype_local":"region",
     "wof:population":1631635,
     "wof:population_rank":12,

--- a/data/856/825/89/85682589.geojson
+++ b/data/856/825/89/85682589.geojson
@@ -5,13 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.03807,
-    "geom:area_square_m":7310445234.539655,
+    "geom:area_square_m":7310445234.539603,
     "geom:bbox":"10.867564,54.5591085,12.554903,56.0105865",
     "geom:latitude":55.281858,
     "geom:longitude":11.702611,
     "iso:country":"DK",
+    "label:dan_x_preferred_longname":[
+        "Region Sj\u00e6lland"
+    ],
+    "label:dan_x_preferred_placetype":[
+        "region"
+    ],
     "label:eng_x_preferred_longname":[
-        "Sj\u00e6lland Region"
+        "Region Zealand"
     ],
     "label:eng_x_preferred_placetype":[
         "region"
@@ -61,19 +67,20 @@
         "Sj\u00e6lland"
     ],
     "name:dan_x_preferred":[
-        "Region Sj\u00e6lland"
+        "Sj\u00e6lland"
     ],
     "name:dan_x_variant":[
-        "Sj\u00e6lland"
+        "Region Sj\u00e6lland"
     ],
     "name:dut_x_preferred":[
         "Seeland"
     ],
     "name:eng_x_preferred":[
-        "Region Zealand"
+        "Zealand"
     ],
     "name:eng_x_variant":[
-        "Zealand"
+        "Region Zealand",
+        "Zealand Region"
     ],
     "name:epo_x_preferred":[
         "Regiono Sj\u00e6lland"
@@ -352,11 +359,10 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1553814872,
-    "wof:name":"Sj\u00e6lland",
+    "wof:lastmodified":1560375933,
+    "wof:name":"Zealand",
     "wof:parent_id":85633121,
     "wof:placetype":"region",
-    "wof:placetype_alt":[],
     "wof:placetype_local":"region",
     "wof:population":805954,
     "wof:population_rank":11,

--- a/data/856/825/93/85682593.geojson
+++ b/data/856/825/93/85682593.geojson
@@ -5,13 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.178758,
-    "geom:area_square_m":7926977195.710023,
+    "geom:area_square_m":7926977195.71002,
     "geom:bbox":"8.2174735,56.5504345,11.2001535,57.752065",
     "geom:latitude":57.053106,
     "geom:longitude":9.671563,
     "iso:country":"DK",
-    "label:eng_x_preferred_longname":[
+    "label:dan_x_preferred_longname":[
         "Nordjylland Region"
+    ],
+    "label:dan_x_preferred_placetype":[
+        "region"
+    ],
+    "label:eng_x_preferred_longname":[
+        "North Jutland Region"
     ],
     "label:eng_x_preferred_placetype":[
         "region"
@@ -61,21 +67,21 @@
         "Nordjylland"
     ],
     "name:dan_x_preferred":[
-        "Region Nordjylland"
+        "Nordjylland"
     ],
     "name:dan_x_variant":[
-        "Nordjylland"
+        "Region Nordjylland"
     ],
     "name:dut_x_preferred":[
         "Noord-Jutland"
     ],
     "name:eng_x_preferred":[
-        "Nordjylland"
+        "North Jutland"
     ],
     "name:eng_x_variant":[
         "North Denmark Region",
         "North Denmark",
-        "North Jutland"
+        "Nordjylland"
     ],
     "name:epo_x_preferred":[
         "Regiono Norda Jutlando"
@@ -354,11 +360,10 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1553814872,
-    "wof:name":"Nordjylland",
+    "wof:lastmodified":1560375943,
+    "wof:name":"North Jutland",
     "wof:parent_id":85633121,
     "wof:placetype":"region",
-    "wof:placetype_alt":[],
     "wof:placetype_local":"region",
     "wof:population":577278,
     "wof:population_rank":11,

--- a/data/856/825/97/85682597.geojson
+++ b/data/856/825/97/85682597.geojson
@@ -10,8 +10,14 @@
     "geom:latitude":56.248759,
     "geom:longitude":9.392629,
     "iso:country":"DK",
+    "label:dan_x_preferred_longname":[
+        "Region Midtjylland"
+    ],
+    "label:dan_x_preferred_placetype":[
+        "region"
+    ],
     "label:eng_x_preferred_longname":[
-        "Midtjylland Region"
+        "Central Jutland Region"
     ],
     "label:eng_x_preferred_placetype":[
         "region"
@@ -64,19 +70,19 @@
         "Midtjylland"
     ],
     "name:dan_x_preferred":[
-        "Region Midtjylland"
+        "Midtjylland"
     ],
     "name:dan_x_variant":[
-        "Midtjylland"
+        "Region Midtjylland"
     ],
     "name:dut_x_preferred":[
         "Midden-Jutland"
     ],
     "name:eng_x_preferred":[
-        "Midtjylland"
+        "Central Jutland"
     ],
     "name:eng_x_variant":[
-        "Central Jutland",
+        "Midtjylland",
         "Region Central Jutland",
         "Central Denmark Region"
     ],
@@ -396,11 +402,10 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1553550706,
-    "wof:name":"Midtjylland",
+    "wof:lastmodified":1560375954,
+    "wof:name":"Central Jutland",
     "wof:parent_id":85633121,
     "wof:placetype":"region",
-    "wof:placetype_alt":[],
     "wof:placetype_local":"region",
     "wof:population":1212787,
     "wof:population_rank":12,


### PR DESCRIPTION
Fixes the Denmark admin1 portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640.

- Updates `wof:name` 
- Verifies `name:eng_x_*` and `name:dan_x_*` property values
- Updates `label:eng_x_*` properties
- Adds `label:dan_x_*` properties

No PIP work required. A follow-up PR can/will be filed to update localadmin records with the same changes.