### PR TITLE
DK concordances, placetype local, and more

### DIFF
--- a/data/115/929/771/7/1159297717.geojson
+++ b/data/115/929/771/7/1159297717.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.675774,
     "lbl:longitude":11.573848,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"316",
+        "dk-geodk:code_qualified":"1085316",
         "eg:gisco_id":"DK_316",
         "eurostat:nuts_2021_id":"316"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700662,
     "wof:geomhash":"070b47bf251cb37749e0bd3d914e9bcd",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352082,
+    "wof:lastmodified":1695876631,
     "wof:name":"Holbaek",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/115/929/771/9/1159297719.geojson
+++ b/data/115/929/771/9/1159297719.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.326944,
     "lbl:longitude":12.334101,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"336",
+        "dk-geodk:code_qualified":"1085336",
         "eg:gisco_id":"DK_336",
         "eurostat:nuts_2021_id":"336"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700664,
     "wof:geomhash":"b077e42857b9ccd4b91c3cabadc7739b",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352083,
+    "wof:lastmodified":1695876632,
     "wof:name":"Stevns",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/115/929/772/1/1159297721.geojson
+++ b/data/115/929/772/1/1159297721.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.076149,
     "lbl:longitude":9.872121,
     "lbl:max_zoom":18.0,
@@ -126,9 +129,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"746",
+        "dk-geodk:code_qualified":"1082746",
         "eg:gisco_id":"DK_746",
         "eurostat:nuts_2021_id":"746"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700669,
     "wof:geomhash":"7e3ddccd0bbd1a105e2475d11832be8d",
@@ -147,7 +156,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352083,
+    "wof:lastmodified":1695876633,
     "wof:name":"Skanderborg",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/115/929/772/3/1159297723.geojson
+++ b/data/115/929/772/3/1159297723.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.781735,
     "lbl:longitude":12.510815,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"173",
+        "dk-geodk:code_qualified":"1084173",
         "eg:gisco_id":"DK_173",
         "eurostat:nuts_2021_id":"173"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700670,
     "wof:geomhash":"d16d107778cfcf9610bc44b5e00d4078",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352084,
+    "wof:lastmodified":1695876633,
     "wof:name":"Lyngby-Taarbaek",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/115/929/772/5/1159297725.geojson
+++ b/data/115/929/772/5/1159297725.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.203869,
     "lbl:longitude":8.933449,
     "lbl:max_zoom":18.0,
@@ -216,9 +219,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"657",
+        "dk-geodk:code_qualified":"1082657",
         "eg:gisco_id":"DK_657",
         "eurostat:nuts_2021_id":"657"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700671,
     "wof:geomhash":"15de19390d45a778bc7fd0ecfd6d9bc5",
@@ -237,7 +246,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352084,
+    "wof:lastmodified":1695876633,
     "wof:name":"Herning",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/115/929/772/7/1159297727.geojson
+++ b/data/115/929/772/7/1159297727.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.698354,
     "lbl:longitude":12.571489,
     "lbl:max_zoom":18.0,
@@ -606,9 +609,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"101",
+        "dk-geodk:code_qualified":"1084101",
         "eg:gisco_id":"DK_101",
         "eurostat:nuts_2021_id":"101"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700672,
     "wof:geomhash":"cfba4ff261a5f5be843a98d01c4a0385",
@@ -627,7 +636,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352085,
+    "wof:lastmodified":1695876634,
     "wof:name":"Copenhagen",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/115/929/772/9/1159297729.geojson
+++ b/data/115/929/772/9/1159297729.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.793708,
     "lbl:longitude":11.985618,
     "lbl:max_zoom":18.0,
@@ -111,9 +114,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"250",
+        "dk-geodk:code_qualified":"1084250",
         "eg:gisco_id":"DK_250",
         "eurostat:nuts_2021_id":"250"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700673,
     "wof:geomhash":"391b3d1dd5879f529c4d445a16dd9f1e",
@@ -132,7 +141,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352086,
+    "wof:lastmodified":1695876635,
     "wof:name":"Frederikssund",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/115/929/773/3/1159297733.geojson
+++ b/data/115/929/773/3/1159297733.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.679988,
     "lbl:longitude":12.347031,
     "lbl:max_zoom":18.0,
@@ -93,9 +96,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"165",
+        "dk-geodk:code_qualified":"1084165",
         "eg:gisco_id":"DK_165",
         "eurostat:nuts_2021_id":"165"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700675,
     "wof:geomhash":"b7804c7a01863ef6207e610cccd8a0da",
@@ -114,7 +123,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352088,
+    "wof:lastmodified":1695876637,
     "wof:name":"Albertslund",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/115/929/773/5/1159297735.geojson
+++ b/data/115/929/773/5/1159297735.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.818602,
     "lbl:longitude":10.58139,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"741",
+        "dk-geodk:code_qualified":"1082741",
         "eg:gisco_id":"DK_741",
         "eurostat:nuts_2021_id":"741"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700676,
     "wof:geomhash":"51c242c18b249c06e19b9c37e8608ed1",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352088,
+    "wof:lastmodified":1695876637,
     "wof:name":"Samso",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/115/929/773/7/1159297737.geojson
+++ b/data/115/929/773/7/1159297737.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":54.814822,
     "lbl:longitude":11.95036,
     "lbl:max_zoom":18.0,
@@ -108,9 +111,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"376",
+        "dk-geodk:code_qualified":"1085376",
         "eg:gisco_id":"DK_376",
         "eurostat:nuts_2021_id":"376"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700677,
     "wof:geomhash":"d942d529d0eb7b37eb2b2368bf8ab157",
@@ -129,7 +138,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352089,
+    "wof:lastmodified":1695876638,
     "wof:name":"Guldborgsund",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/115/929/773/9/1159297739.geojson
+++ b/data/115/929/773/9/1159297739.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.996891,
     "lbl:longitude":12.002503,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"260",
+        "dk-geodk:code_qualified":"1084260",
         "eg:gisco_id":"DK_260",
         "eurostat:nuts_2021_id":"260"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700679,
     "wof:geomhash":"b1e31343fe9b6ce5c2b9588abe9b7fcc",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352091,
+    "wof:lastmodified":1695876641,
     "wof:name":"Halsnaes",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/115/929/774/1/1159297741.geojson
+++ b/data/115/929/774/1/1159297741.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.813064,
     "lbl:longitude":9.364557,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"820",
+        "dk-geodk:code_qualified":"1081820",
         "eg:gisco_id":"DK_820",
         "eurostat:nuts_2021_id":"820"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700680,
     "wof:geomhash":"c5b3e7de0c26fdc46ca2814b7160a59d",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352092,
+    "wof:lastmodified":1695876641,
     "wof:name":"Vesthimmerland",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/115/929/774/3/1159297743.geojson
+++ b/data/115/929/774/3/1159297743.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.973578,
     "lbl:longitude":9.924653,
     "lbl:max_zoom":18.0,
@@ -306,9 +309,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"851",
+        "dk-geodk:code_qualified":"1081851",
         "eg:gisco_id":"DK_851",
         "eurostat:nuts_2021_id":"851"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700682,
     "wof:geomhash":"0ce43081ff1f2327aa251b36152d710d",
@@ -327,7 +336,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352093,
+    "wof:lastmodified":1695876643,
     "wof:name":"Aalborg",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/115/929/774/5/1159297745.geojson
+++ b/data/115/929/774/5/1159297745.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.297678,
     "lbl:longitude":9.906816,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"710",
+        "dk-geodk:code_qualified":"1082710",
         "eg:gisco_id":"DK_710",
         "eurostat:nuts_2021_id":"710"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700684,
     "wof:geomhash":"c34928d6440cc341a91384d87cb41f29",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352095,
+    "wof:lastmodified":1695876645,
     "wof:name":"Favrskov",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/115/929/774/7/1159297747.geojson
+++ b/data/115/929/774/7/1159297747.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.232202,
     "lbl:longitude":9.37495,
     "lbl:max_zoom":18.0,
@@ -157,9 +160,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"510",
+        "dk-geodk:code_qualified":"1083510",
         "eg:gisco_id":"DK_510",
         "eurostat:nuts_2021_id":"510"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700685,
     "wof:geomhash":"10054075ea5d07be366b5e53cf8316f6",
@@ -179,7 +188,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352095,
+    "wof:lastmodified":1695876646,
     "wof:name":"Haderslev",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/115/929/775/1/1159297751.geojson
+++ b/data/115/929/775/1/1159297751.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.459381,
     "lbl:longitude":9.05166,
     "lbl:max_zoom":18.0,
@@ -103,9 +106,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"575",
+        "dk-geodk:code_qualified":"1083575",
         "eg:gisco_id":"DK_575",
         "eurostat:nuts_2021_id":"575"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700687,
     "wof:geomhash":"bd41f9bf841d8c6cb3470c8935383e06",
@@ -125,7 +134,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352097,
+    "wof:lastmodified":1695876648,
     "wof:name":"Vejen",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/115/929/775/3/1159297753.geojson
+++ b/data/115/929/775/3/1159297753.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":57.234638,
     "lbl:longitude":10.128114,
     "lbl:max_zoom":18.0,
@@ -72,9 +75,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"810",
+        "dk-geodk:code_qualified":"1081810",
         "eg:gisco_id":"DK_810",
         "eurostat:nuts_2021_id":"810"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700687,
     "wof:geomhash":"6611324c446d6f2de1555b6977b97329",
@@ -93,7 +102,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352098,
+    "wof:lastmodified":1695876649,
     "wof:name":"Bronderslev",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/115/929/775/5/1159297755.geojson
+++ b/data/115/929/775/5/1159297755.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.503482,
     "lbl:longitude":10.668336,
     "lbl:max_zoom":18.0,
@@ -121,9 +124,15 @@
     "wof:breaches":[],
     "wof:concordance":{},
     "wof:concordances":{
+        "dk-geodk:code":"440",
+        "dk-geodk:code_qualified":"1083440",
         "eg:gisco_id":"DK_440",
         "eurostat:nuts_2021_id":"440"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:created":1524700688,
     "wof:geomhash":"6eab7335b0e09563f633aac2c2050075",
@@ -143,7 +152,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352098,
+    "wof:lastmodified":1695876649,
     "wof:name":"Kerteminde",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/397/5/1394013975.geojson
+++ b/data/139/401/397/5/1394013975.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.544866,
     "lbl:longitude":10.112301,
     "lbl:max_zoom":18.0,
@@ -220,9 +223,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"730",
+        "dk-geodk:code_qualified":"1082730",
         "eg:gisco_id":"DK_730",
         "eurostat:nuts_2021_id":"730"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"ef19e596cc2acc453b6aadd6f0fe63d7",
     "wof:hierarchy":[
@@ -240,7 +249,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352099,
+    "wof:lastmodified":1695876650,
     "wof:name":"Randers",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/397/7/1394013977.geojson
+++ b/data/139/401/397/7/1394013977.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.134744,
     "lbl:longitude":10.13517,
     "lbl:max_zoom":18.0,
@@ -328,9 +331,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"751",
+        "dk-geodk:code_qualified":"1082751",
         "eg:gisco_id":"DK_751",
         "eurostat:nuts_2021_id":"751"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"6782daa01484de782fb3b1663ad74fd0",
     "wof:hierarchy":[
@@ -348,7 +357,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352100,
+    "wof:lastmodified":1695876651,
     "wof:name":"Aarhus",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/397/9/1394013979.geojson
+++ b/data/139/401/397/9/1394013979.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.30636,
     "lbl:longitude":11.71137,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"370",
+        "dk-geodk:code_qualified":"1085370",
         "eg:gisco_id":"DK_370",
         "eurostat:nuts_2021_id":"370"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"78b074b7c6ec524030ff6beacf28f161",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352101,
+    "wof:lastmodified":1695876652,
     "wof:name":"Naestved",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/398/1/1394013981.geojson
+++ b/data/139/401/398/1/1394013981.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.363912,
     "lbl:longitude":11.349646,
     "lbl:max_zoom":18.0,
@@ -163,9 +166,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"330",
+        "dk-geodk:code_qualified":"1085330",
         "eg:gisco_id":"DK_330",
         "eurostat:nuts_2021_id":"330"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"424fa60c76e8ab245029ab4535324869",
     "wof:hierarchy":[
@@ -183,7 +192,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352102,
+    "wof:lastmodified":1695876654,
     "wof:name":"Slagelse",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/398/3/1394013983.geojson
+++ b/data/139/401/398/3/1394013983.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":54.822893,
     "lbl:longitude":11.277346,
     "lbl:max_zoom":18.0,
@@ -208,9 +211,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"360",
+        "dk-geodk:code_qualified":"1085360",
         "eg:gisco_id":"DK_360",
         "eurostat:nuts_2021_id":"360"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"9fca8a0e9086e88c45c59b9a6685b9ae",
     "wof:hierarchy":[
@@ -228,7 +237,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352104,
+    "wof:lastmodified":1695876656,
     "wof:name":"Lolland",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/398/5/1394013985.geojson
+++ b/data/139/401/398/5/1394013985.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.631758,
     "lbl:longitude":11.237201,
     "lbl:max_zoom":18.0,
@@ -136,9 +139,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"326",
+        "dk-geodk:code_qualified":"1085326",
         "eg:gisco_id":"DK_326",
         "eurostat:nuts_2021_id":"326"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"dea2ab7ef9c5d4e8be6dc7f6ffa722a6",
     "wof:hierarchy":[
@@ -156,7 +165,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352105,
+    "wof:lastmodified":1695876657,
     "wof:name":"Kalundborg",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/398/9/1394013989.geojson
+++ b/data/139/401/398/9/1394013989.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":57.263467,
     "lbl:longitude":11.010176,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"825",
+        "dk-geodk:code_qualified":"1081825",
         "eg:gisco_id":"DK_825",
         "eurostat:nuts_2021_id":"825"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"594577603e28f2f6a39827dfcdf847de",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352107,
+    "wof:lastmodified":1695876659,
     "wof:name":"Laeso",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/399/1/1394013991.geojson
+++ b/data/139/401/399/1/1394013991.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":54.919245,
     "lbl:longitude":10.768816,
     "lbl:max_zoom":18.0,
@@ -179,9 +182,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"482",
+        "dk-geodk:code_qualified":"1083482",
         "eg:gisco_id":"DK_482",
         "eurostat:nuts_2021_id":"482"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"4ba40b1412c96113ed26c8e8907e7799",
     "wof:hierarchy":[
@@ -200,7 +209,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352108,
+    "wof:lastmodified":1695876661,
     "wof:name":"Langeland",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/399/3/1394013993.geojson
+++ b/data/139/401/399/3/1394013993.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.062317,
     "lbl:longitude":11.967766,
     "lbl:max_zoom":18.0,
@@ -121,9 +124,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"390",
+        "dk-geodk:code_qualified":"1085390",
         "eg:gisco_id":"DK_390",
         "eurostat:nuts_2021_id":"390"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"fd7ca47e8837983f55a48ff071d0f2d6",
     "wof:hierarchy":[
@@ -141,7 +150,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352109,
+    "wof:lastmodified":1695876662,
     "wof:name":"Vordingborg",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/399/5/1394013995.geojson
+++ b/data/139/401/399/5/1394013995.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.121776,
     "lbl:longitude":14.91034,
     "lbl:max_zoom":18.0,
@@ -268,9 +271,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"400",
+        "dk-geodk:code_qualified":"1084400",
         "eg:gisco_id":"DK_400",
         "eurostat:nuts_2021_id":"400"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"e31d7540cd0636b3da7567bc72fa8620",
     "wof:hierarchy":[
@@ -288,7 +297,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352112,
+    "wof:lastmodified":1695876665,
     "wof:name":"Bornholm",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/399/7/1394013997.geojson
+++ b/data/139/401/399/7/1394013997.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.599736,
     "lbl:longitude":12.595438,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"185",
+        "dk-geodk:code_qualified":"1084185",
         "eg:gisco_id":"DK_185",
         "eurostat:nuts_2021_id":"185"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"836a45970ddab51b5541b21f916411cd",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352114,
+    "wof:lastmodified":1695876668,
     "wof:name":"Tarnby",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/399/9/1394013999.geojson
+++ b/data/139/401/399/9/1394013999.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.624476,
     "lbl:longitude":12.112954,
     "lbl:max_zoom":18.0,
@@ -256,9 +259,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"265",
+        "dk-geodk:code_qualified":"1085265",
         "eg:gisco_id":"DK_265",
         "eurostat:nuts_2021_id":"265"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"a7a92c97eab4d54747e5676eedfc589a",
     "wof:hierarchy":[
@@ -276,7 +285,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352115,
+    "wof:lastmodified":1695876669,
     "wof:name":"Roskilde",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/400/1/1394014001.geojson
+++ b/data/139/401/400/1/1394014001.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":57.418409,
     "lbl:longitude":10.451791,
     "lbl:max_zoom":18.0,
@@ -196,9 +199,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"813",
+        "dk-geodk:code_qualified":"1081813",
         "eg:gisco_id":"DK_813",
         "eurostat:nuts_2021_id":"813"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"db149c81e56bc1695fbc33fc7326e4ed",
     "wof:hierarchy":[
@@ -216,7 +225,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352116,
+    "wof:lastmodified":1695876670,
     "wof:name":"Frederikshavn",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/400/3/1394014003.geojson
+++ b/data/139/401/400/3/1394014003.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":57.133592,
     "lbl:longitude":9.534246,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"849",
+        "dk-geodk:code_qualified":"1081849",
         "eg:gisco_id":"DK_849",
         "eurostat:nuts_2021_id":"849"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"358ff33df7b69f0ebc75a528a724203b",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352117,
+    "wof:lastmodified":1695876671,
     "wof:name":"Jammerbugt",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/400/7/1394014007.geojson
+++ b/data/139/401/400/7/1394014007.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.801322,
     "lbl:longitude":8.752051,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"773",
+        "dk-geodk:code_qualified":"1081773",
         "eg:gisco_id":"DK_773",
         "eurostat:nuts_2021_id":"773"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f2cc8d6af5b6c5c45d965f159b55b408",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352118,
+    "wof:lastmodified":1695876672,
     "wof:name":"Morso",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/400/9/1394014009.geojson
+++ b/data/139/401/400/9/1394014009.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.933349,
     "lbl:longitude":8.523195,
     "lbl:max_zoom":18.0,
@@ -142,9 +145,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"787",
+        "dk-geodk:code_qualified":"1081787",
         "eg:gisco_id":"DK_787",
         "eurostat:nuts_2021_id":"787"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"efd69bd7194a5c56d08f16a8018ba219",
     "wof:hierarchy":[
@@ -162,7 +171,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352119,
+    "wof:lastmodified":1695876673,
     "wof:name":"Thisted",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/401/1/1394014011.geojson
+++ b/data/139/401/401/1/1394014011.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.452023,
     "lbl:longitude":10.765887,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"707",
+        "dk-geodk:code_qualified":"1082707",
         "eg:gisco_id":"DK_707",
         "eurostat:nuts_2021_id":"707"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f778501973d7a12b32ca208fab76d784",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352120,
+    "wof:lastmodified":1695876674,
     "wof:name":"Norddjurs",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/401/3/1394014013.geojson
+++ b/data/139/401/401/3/1394014013.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.037399,
     "lbl:longitude":12.51109,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"217",
+        "dk-geodk:code_qualified":"1084217",
         "eg:gisco_id":"DK_217",
         "eurostat:nuts_2021_id":"217"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"a885ff323bd06b54c18591684f72328b",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352120,
+    "wof:lastmodified":1695876675,
     "wof:name":"Helsingor",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/401/5/1394014015.geojson
+++ b/data/139/401/401/5/1394014015.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.353181,
     "lbl:longitude":8.598617,
     "lbl:max_zoom":18.0,
@@ -172,9 +175,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"661",
+        "dk-geodk:code_qualified":"1082661",
         "eg:gisco_id":"DK_661",
         "eurostat:nuts_2021_id":"661"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"e824ef235017143487795585d43a331f",
     "wof:hierarchy":[
@@ -192,7 +201,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352121,
+    "wof:lastmodified":1695876676,
     "wof:name":"Holstebro",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/401/7/1394014017.geojson
+++ b/data/139/401/401/7/1394014017.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.861136,
     "lbl:longitude":11.597819,
     "lbl:max_zoom":18.0,
@@ -85,9 +88,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"306",
+        "dk-geodk:code_qualified":"1085306",
         "eg:gisco_id":"DK_306",
         "eurostat:nuts_2021_id":"306"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f45dd5d988da117293e1815f0088b970",
     "wof:hierarchy":[
@@ -105,7 +114,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352121,
+    "wof:lastmodified":1695876676,
     "wof:name":"Odsherred",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/401/9/1394014019.geojson
+++ b/data/139/401/401/9/1394014019.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.020608,
     "lbl:longitude":8.50303,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"760",
+        "dk-geodk:code_qualified":"1082760",
         "eg:gisco_id":"DK_760",
         "eurostat:nuts_2021_id":"760"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"e06146d6c41219520573905652ac57e0",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352122,
+    "wof:lastmodified":1695876677,
     "wof:name":"Ringkobing-Skjern",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/402/1/1394014021.geojson
+++ b/data/139/401/402/1/1394014021.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.736079,
     "lbl:longitude":12.428081,
     "lbl:max_zoom":18.0,
@@ -88,9 +91,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"163",
+        "dk-geodk:code_qualified":"1084163",
         "eg:gisco_id":"DK_163",
         "eurostat:nuts_2021_id":"163"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"1252666f0d30f8f15ed58b4a3f2d88ed",
     "wof:hierarchy":[
@@ -108,7 +117,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352124,
+    "wof:lastmodified":1695876680,
     "wof:name":"Herlev",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/402/5/1394014025.geojson
+++ b/data/139/401/402/5/1394014025.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.626309,
     "lbl:longitude":12.469279,
     "lbl:max_zoom":18.0,
@@ -94,9 +97,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"167",
+        "dk-geodk:code_qualified":"1084167",
         "eg:gisco_id":"DK_167",
         "eurostat:nuts_2021_id":"167"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"7c821c378a29b7b71d76b74eb5c8835e",
     "wof:hierarchy":[
@@ -114,7 +123,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352124,
+    "wof:lastmodified":1695876680,
     "wof:name":"Hvidovre",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/402/7/1394014027.geojson
+++ b/data/139/401/402/7/1394014027.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.449383,
     "lbl:longitude":12.09953,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"259",
+        "dk-geodk:code_qualified":"1085259",
         "eg:gisco_id":"DK_259",
         "eurostat:nuts_2021_id":"259"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"44151304c6913e0fcd080fa4582504aa",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352125,
+    "wof:lastmodified":1695876680,
     "wof:name":"Koge",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/402/9/1394014029.geojson
+++ b/data/139/401/402/9/1394014029.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.380682,
     "lbl:longitude":10.31865,
     "lbl:max_zoom":18.0,
@@ -323,9 +326,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"461",
+        "dk-geodk:code_qualified":"1083461",
         "eg:gisco_id":"DK_461",
         "eurostat:nuts_2021_id":"461"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"b4378bd6a9bde533ff4b3471413b6f52",
     "wof:hierarchy":[
@@ -344,7 +353,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352125,
+    "wof:lastmodified":1695876681,
     "wof:name":"Odense",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/403/1/1394014031.geojson
+++ b/data/139/401/403/1/1394014031.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.690543,
     "lbl:longitude":8.629994,
     "lbl:max_zoom":18.0,
@@ -119,9 +122,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"573",
+        "dk-geodk:code_qualified":"1083573",
         "eg:gisco_id":"DK_573",
         "eurostat:nuts_2021_id":"573"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"2e85c5510433912fb09128656e7a8843",
     "wof:hierarchy":[
@@ -140,7 +149,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352126,
+    "wof:lastmodified":1695876681,
     "wof:name":"Varde",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/403/3/1394014033.geojson
+++ b/data/139/401/403/3/1394014033.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.940749,
     "lbl:longitude":10.143953,
     "lbl:max_zoom":18.0,
@@ -103,9 +106,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"727",
+        "dk-geodk:code_qualified":"1082727",
         "eg:gisco_id":"DK_727",
         "eurostat:nuts_2021_id":"727"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"abc721f8056f105cf30ee9bc174159e5",
     "wof:hierarchy":[
@@ -123,7 +132,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352127,
+    "wof:lastmodified":1695876683,
     "wof:name":"Odder",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/403/5/1394014035.geojson
+++ b/data/139/401/403/5/1394014035.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.726028,
     "lbl:longitude":9.913262,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"846",
+        "dk-geodk:code_qualified":"1081846",
         "eg:gisco_id":"DK_846",
         "eurostat:nuts_2021_id":"846"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"db09ea0ecf081d0bc74d96c678a28584",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352127,
+    "wof:lastmodified":1695876683,
     "wof:name":"Mariagerfjord",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/403/7/1394014037.geojson
+++ b/data/139/401/403/7/1394014037.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.565691,
     "lbl:longitude":9.686171,
     "lbl:max_zoom":18.0,
@@ -200,9 +203,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"607",
+        "dk-geodk:code_qualified":"1083607",
         "eg:gisco_id":"DK_607",
         "eurostat:nuts_2021_id":"607"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"10b3a87acca1f48c4848dc09b2c16db0",
     "wof:hierarchy":[
@@ -221,7 +230,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352129,
+    "wof:lastmodified":1695876685,
     "wof:name":"Fredericia",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/403/9/1394014039.geojson
+++ b/data/139/401/403/9/1394014039.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.532854,
     "lbl:longitude":12.175457,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"269",
+        "dk-geodk:code_qualified":"1085269",
         "eg:gisco_id":"DK_269",
         "eurostat:nuts_2021_id":"269"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"8f03c64dd94fe0d1f1492bc9b5cea706",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352129,
+    "wof:lastmodified":1695876685,
     "wof:name":"Solrod",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/404/3/1394014043.geojson
+++ b/data/139/401/404/3/1394014043.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.123871,
     "lbl:longitude":10.65236,
     "lbl:max_zoom":18.0,
@@ -167,9 +170,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"479",
+        "dk-geodk:code_qualified":"1083479",
         "eg:gisco_id":"DK_479",
         "eurostat:nuts_2021_id":"479"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"8dd3a65f619d1a98c6de54291e1b3b61",
     "wof:hierarchy":[
@@ -188,7 +197,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352129,
+    "wof:lastmodified":1695876686,
     "wof:name":"Svendborg",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/404/5/1394014045.geojson
+++ b/data/139/401/404/5/1394014045.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.445263,
     "lbl:longitude":9.396247,
     "lbl:max_zoom":18.0,
@@ -224,9 +227,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"621",
+        "dk-geodk:code_qualified":"1083621",
         "eg:gisco_id":"DK_621",
         "eurostat:nuts_2021_id":"621"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"551069ac62f15816ddb7b0ab969a888a",
     "wof:hierarchy":[
@@ -245,7 +254,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352130,
+    "wof:lastmodified":1695876687,
     "wof:name":"Kolding",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/404/7/1394014047.geojson
+++ b/data/139/401/404/7/1394014047.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.459626,
     "lbl:longitude":8.570655,
     "lbl:max_zoom":18.0,
@@ -76,9 +79,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"671",
+        "dk-geodk:code_qualified":"1082671",
         "eg:gisco_id":"DK_671",
         "eurostat:nuts_2021_id":"671"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"55b86f6746f2a56e56402e4e0730f95a",
     "wof:hierarchy":[
@@ -96,7 +105,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352131,
+    "wof:lastmodified":1695876688,
     "wof:name":"Struer",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/404/9/1394014049.geojson
+++ b/data/139/401/404/9/1394014049.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":54.958757,
     "lbl:longitude":9.926706,
     "lbl:max_zoom":18.0,
@@ -71,9 +74,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"540",
+        "dk-geodk:code_qualified":"1083540",
         "eg:gisco_id":"DK_540",
         "eurostat:nuts_2021_id":"540"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"1311dca6e6dfafbb362af4a27f539056",
     "wof:hierarchy":[
@@ -92,7 +101,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352132,
+    "wof:lastmodified":1695876689,
     "wof:name":"Sonderborg",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/405/1/1394014051.geojson
+++ b/data/139/401/405/1/1394014051.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.498535,
     "lbl:longitude":9.512808,
     "lbl:max_zoom":18.0,
@@ -133,9 +136,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"791",
+        "dk-geodk:code_qualified":"1082791",
         "eg:gisco_id":"DK_791",
         "eurostat:nuts_2021_id":"791"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"93f68f68e3e4efe5bd76cc4e07171e2e",
     "wof:hierarchy":[
@@ -153,7 +162,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352134,
+    "wof:lastmodified":1695876691,
     "wof:name":"Viborg",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/405/3/1394014053.geojson
+++ b/data/139/401/405/3/1394014053.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.523954,
     "lbl:longitude":10.244895,
     "lbl:max_zoom":18.0,
@@ -71,9 +74,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"480",
+        "dk-geodk:code_qualified":"1083480",
         "eg:gisco_id":"DK_480",
         "eurostat:nuts_2021_id":"480"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"1ab916408ce6230bb7f56e3081a6ce9b",
     "wof:hierarchy":[
@@ -92,7 +101,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352135,
+    "wof:lastmodified":1695876692,
     "wof:name":"Nordfyns",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/405/5/1394014055.geojson
+++ b/data/139/401/405/5/1394014055.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.198721,
     "lbl:longitude":10.351212,
     "lbl:max_zoom":18.0,
@@ -71,9 +74,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"430",
+        "dk-geodk:code_qualified":"1083430",
         "eg:gisco_id":"DK_430",
         "eurostat:nuts_2021_id":"430"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"04e402626f38a84d62ff85dbc4d3608b",
     "wof:hierarchy":[
@@ -92,7 +101,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352136,
+    "wof:lastmodified":1695876693,
     "wof:name":"Faaborg-Midtfyn",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/405/7/1394014057.geojson
+++ b/data/139/401/405/7/1394014057.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.593399,
     "lbl:longitude":12.646375,
     "lbl:max_zoom":18.0,
@@ -76,9 +79,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"155",
+        "dk-geodk:code_qualified":"1084155",
         "eg:gisco_id":"DK_155",
         "eurostat:nuts_2021_id":"155"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"0c948b0f44ae95dbdaf2d3652041ec7d",
     "wof:hierarchy":[
@@ -96,7 +105,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352137,
+    "wof:lastmodified":1695876694,
     "wof:name":"Dragor",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/406/1/1394014061.geojson
+++ b/data/139/401/406/1/1394014061.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.79822,
     "lbl:longitude":12.374083,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"190",
+        "dk-geodk:code_qualified":"1084190",
         "eg:gisco_id":"DK_190",
         "eurostat:nuts_2021_id":"190"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"730af82dc28d3e5f5238f43a2c749040",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352137,
+    "wof:lastmodified":1695876695,
     "wof:name":"Fureso",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/406/3/1394014063.geojson
+++ b/data/139/401/406/3/1394014063.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.444515,
     "lbl:longitude":9.893097,
     "lbl:max_zoom":18.0,
@@ -116,9 +119,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"410",
+        "dk-geodk:code_qualified":"1083410",
         "eg:gisco_id":"DK_410",
         "eurostat:nuts_2021_id":"410"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"329cc3b369c9f16a4a7291c3a3f35592",
     "wof:hierarchy":[
@@ -137,7 +146,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352137,
+    "wof:lastmodified":1695876695,
     "wof:name":"Middelfart",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/406/5/1394014065.geojson
+++ b/data/139/401/406/5/1394014065.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.397337,
     "lbl:longitude":8.422977,
     "lbl:max_zoom":18.0,
@@ -224,9 +227,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"563",
+        "dk-geodk:code_qualified":"1083563",
         "eg:gisco_id":"DK_563",
         "eurostat:nuts_2021_id":"563"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"18b026b7171af80d3bf2772120ffe7a1",
     "wof:hierarchy":[
@@ -245,7 +254,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352138,
+    "wof:lastmodified":1695876696,
     "wof:name":"Fano",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/406/7/1394014067.geojson
+++ b/data/139/401/406/7/1394014067.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.627139,
     "lbl:longitude":11.880457,
     "lbl:max_zoom":18.0,
@@ -112,9 +115,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"350",
+        "dk-geodk:code_qualified":"1085350",
         "eg:gisco_id":"DK_350",
         "eurostat:nuts_2021_id":"350"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"8cfafc66bc191108b21ca11ac19492a4",
     "wof:hierarchy":[
@@ -132,7 +141,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352139,
+    "wof:lastmodified":1695876697,
     "wof:name":"Lejre",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/406/9/1394014069.geojson
+++ b/data/139/401/406/9/1394014069.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":54.860453,
     "lbl:longitude":10.385656,
     "lbl:max_zoom":18.0,
@@ -134,9 +137,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"492",
+        "dk-geodk:code_qualified":"1083492",
         "eg:gisco_id":"DK_492",
         "eurostat:nuts_2021_id":"492"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"a7deb1623f28417c20b6c4e26f52bb70",
     "wof:hierarchy":[
@@ -155,7 +164,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352140,
+    "wof:lastmodified":1695876698,
     "wof:name":"Aero",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/407/1/1394014071.geojson
+++ b/data/139/401/407/1/1394014071.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.294274,
     "lbl:longitude":10.068345,
     "lbl:max_zoom":18.0,
@@ -104,9 +107,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"420",
+        "dk-geodk:code_qualified":"1083420",
         "eg:gisco_id":"DK_420",
         "eurostat:nuts_2021_id":"420"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"531db445b33f67788b1afe1e4fef6f9a",
     "wof:hierarchy":[
@@ -125,7 +134,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352140,
+    "wof:lastmodified":1695876699,
     "wof:name":"Assens",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/407/3/1394014073.geojson
+++ b/data/139/401/407/3/1394014073.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.620044,
     "lbl:longitude":8.955638,
     "lbl:max_zoom":18.0,
@@ -82,9 +85,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"779",
+        "dk-geodk:code_qualified":"1082779",
         "eg:gisco_id":"DK_779",
         "eurostat:nuts_2021_id":"779"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"a1080d1d0f38ee44b17e3f8f7e1beff7",
     "wof:hierarchy":[
@@ -102,7 +111,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352141,
+    "wof:lastmodified":1695876700,
     "wof:name":"Skive",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/407/5/1394014075.geojson
+++ b/data/139/401/407/5/1394014075.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.465013,
     "lbl:longitude":8.253585,
     "lbl:max_zoom":18.0,
@@ -127,9 +130,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"665",
+        "dk-geodk:code_qualified":"1082665",
         "eg:gisco_id":"DK_665",
         "eurostat:nuts_2021_id":"665"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"c6522092f3fa8d66b52a30daaf4edfe5",
     "wof:hierarchy":[
@@ -147,7 +156,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352143,
+    "wof:lastmodified":1695876702,
     "wof:name":"Lemvig",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/407/9/1394014079.geojson
+++ b/data/139/401/407/9/1394014079.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.878078,
     "lbl:longitude":9.770007,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"840",
+        "dk-geodk:code_qualified":"1081840",
         "eg:gisco_id":"DK_840",
         "eurostat:nuts_2021_id":"840"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"23ce16b314ecfce45c0179629e8e3fe5",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352143,
+    "wof:lastmodified":1695876703,
     "wof:name":"Rebild",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/408/1/1394014081.geojson
+++ b/data/139/401/408/1/1394014081.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.336728,
     "lbl:longitude":10.563278,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"706",
+        "dk-geodk:code_qualified":"1082706",
         "eg:gisco_id":"DK_706",
         "eurostat:nuts_2021_id":"706"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"36e9008dab6861cbbe1c939b4ea6d768",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352144,
+    "wof:lastmodified":1695876703,
     "wof:name":"Syddjurs",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/408/3/1394014083.geojson
+++ b/data/139/401/408/3/1394014083.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.922471,
     "lbl:longitude":9.765591,
     "lbl:max_zoom":18.0,
@@ -220,9 +223,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"615",
+        "dk-geodk:code_qualified":"1082615",
         "eg:gisco_id":"DK_615",
         "eurostat:nuts_2021_id":"615"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f84965c3d2e7c2d334222052e11b282d",
     "wof:hierarchy":[
@@ -240,7 +249,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352145,
+    "wof:lastmodified":1695876704,
     "wof:name":"Horsens",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/408/5/1394014085.geojson
+++ b/data/139/401/408/5/1394014085.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.923173,
     "lbl:longitude":12.235777,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"219",
+        "dk-geodk:code_qualified":"1084219",
         "eg:gisco_id":"DK_219",
         "eurostat:nuts_2021_id":"219"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"cb09da707fef0082993d03a502285a93",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352145,
+    "wof:lastmodified":1695876705,
     "wof:name":"Hillerod",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/408/7/1394014087.geojson
+++ b/data/139/401/408/7/1394014087.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.759634,
     "lbl:longitude":9.746159,
     "lbl:max_zoom":18.0,
@@ -103,9 +106,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"766",
+        "dk-geodk:code_qualified":"1082766",
         "eg:gisco_id":"DK_766",
         "eurostat:nuts_2021_id":"766"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"4e6f973d9d271ef8a978db698bd41e09",
     "wof:hierarchy":[
@@ -123,7 +132,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352146,
+    "wof:lastmodified":1695876706,
     "wof:name":"Hedensted",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/408/9/1394014089.geojson
+++ b/data/139/401/408/9/1394014089.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.886407,
     "lbl:longitude":12.512593,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"223",
+        "dk-geodk:code_qualified":"1084223",
         "eg:gisco_id":"DK_223",
         "eurostat:nuts_2021_id":"223"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"a32d5a580ff4cfe4b0616aef4cfdf72d",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352146,
+    "wof:lastmodified":1695876707,
     "wof:name":"Horsholm",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/409/1/1394014091.geojson
+++ b/data/139/401/409/1/1394014091.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.061303,
     "lbl:longitude":8.858588,
     "lbl:max_zoom":18.0,
@@ -71,9 +74,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"550",
+        "dk-geodk:code_qualified":"1083550",
         "eg:gisco_id":"DK_550",
         "eurostat:nuts_2021_id":"550"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"ce966207222026cf00c30695d9e514ff",
     "wof:hierarchy":[
@@ -92,7 +101,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352147,
+    "wof:lastmodified":1695876707,
     "wof:name":"Tonder",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/409/3/1394014093.geojson
+++ b/data/139/401/409/3/1394014093.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":54.987092,
     "lbl:longitude":9.293399,
     "lbl:max_zoom":18.0,
@@ -176,9 +179,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"580",
+        "dk-geodk:code_qualified":"1083580",
         "eg:gisco_id":"DK_580",
         "eurostat:nuts_2021_id":"580"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"da046a68ee00fcea46899fc963bd795b",
     "wof:hierarchy":[
@@ -197,7 +206,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352148,
+    "wof:lastmodified":1695876708,
     "wof:name":"Aabenraa",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/409/7/1394014097.geojson
+++ b/data/139/401/409/7/1394014097.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.784309,
     "lbl:longitude":12.223539,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"240",
+        "dk-geodk:code_qualified":"1084240",
         "eg:gisco_id":"DK_240",
         "eurostat:nuts_2021_id":"240"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f45e6c9a075c9ca7729869480f746ac3",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352148,
+    "wof:lastmodified":1695876709,
     "wof:name":"Egedal",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/409/9/1394014099.geojson
+++ b/data/139/401/409/9/1394014099.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.497443,
     "lbl:longitude":11.561433,
     "lbl:max_zoom":18.0,
@@ -106,9 +109,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"340",
+        "dk-geodk:code_qualified":"1085340",
         "eg:gisco_id":"DK_340",
         "eurostat:nuts_2021_id":"340"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"3f8d3e09fa91e9d2bc40f0646f65c080",
     "wof:hierarchy":[
@@ -126,7 +135,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352149,
+    "wof:lastmodified":1695876709,
     "wof:name":"Soro",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/410/1/1394014101.geojson
+++ b/data/139/401/410/1/1394014101.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.721041,
     "lbl:longitude":9.36036,
     "lbl:max_zoom":18.0,
@@ -236,9 +239,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"630",
+        "dk-geodk:code_qualified":"1083630",
         "eg:gisco_id":"DK_630",
         "eurostat:nuts_2021_id":"630"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"e3a8da7a510958b50900c1ce72f44740",
     "wof:hierarchy":[
@@ -257,7 +266,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352149,
+    "wof:lastmodified":1695876710,
     "wof:name":"Vejle",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/410/3/1394014103.geojson
+++ b/data/139/401/410/3/1394014103.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.420435,
     "lbl:longitude":8.737209,
     "lbl:max_zoom":18.0,
@@ -260,9 +263,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"561",
+        "dk-geodk:code_qualified":"1083561",
         "eg:gisco_id":"DK_561",
         "eurostat:nuts_2021_id":"561"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"9d4c4e2db6ce6dfc7ca407e355ab464c",
     "wof:hierarchy":[
@@ -281,7 +290,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352150,
+    "wof:lastmodified":1695876711,
     "wof:name":"Esbjerg",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/410/5/1394014105.geojson
+++ b/data/139/401/410/5/1394014105.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.633296,
     "lbl:longitude":12.373513,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"187",
+        "dk-geodk:code_qualified":"1084187",
         "eg:gisco_id":"DK_187",
         "eurostat:nuts_2021_id":"187"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"4a034922ccffb8faa095dc9782e70664",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352151,
+    "wof:lastmodified":1695876712,
     "wof:name":"Vallensbaek",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/410/7/1394014107.geojson
+++ b/data/139/401/410/7/1394014107.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.030341,
     "lbl:longitude":9.254872,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"756",
+        "dk-geodk:code_qualified":"1082756",
         "eg:gisco_id":"DK_756",
         "eurostat:nuts_2021_id":"756"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f2c6f1aabed91b63edca520187734fc0",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352151,
+    "wof:lastmodified":1695876712,
     "wof:name":"Ikast-Brande",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/410/9/1394014109.geojson
+++ b/data/139/401/410/9/1394014109.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.742231,
     "lbl:longitude":12.469709,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"159",
+        "dk-geodk:code_qualified":"1084159",
         "eg:gisco_id":"DK_159",
         "eurostat:nuts_2021_id":"159"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f49e379b67042b27d97d5878178ffe96",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352151,
+    "wof:lastmodified":1695876713,
     "wof:name":"Gladsaxe",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/411/1/1394014111.geojson
+++ b/data/139/401/411/1/1394014111.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.055766,
     "lbl:longitude":12.232955,
     "lbl:max_zoom":18.0,
@@ -85,9 +88,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"270",
+        "dk-geodk:code_qualified":"1084270",
         "eg:gisco_id":"DK_270",
         "eurostat:nuts_2021_id":"270"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"8132e83909dc433592aca7b04e8289ec",
     "wof:hierarchy":[
@@ -105,7 +114,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352151,
+    "wof:lastmodified":1695876713,
     "wof:name":"Gribskov",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/411/5/1394014115.geojson
+++ b/data/139/401/411/5/1394014115.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.748478,
     "lbl:longitude":12.547762,
     "lbl:max_zoom":18.0,
@@ -76,9 +79,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"157",
+        "dk-geodk:code_qualified":"1084157",
         "eg:gisco_id":"DK_157",
         "eurostat:nuts_2021_id":"157"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"76dead25b01a30ae1626c650657d7315",
     "wof:hierarchy":[
@@ -96,7 +105,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352152,
+    "wof:lastmodified":1695876713,
     "wof:name":"Gentofte",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/411/7/1394014117.geojson
+++ b/data/139/401/411/7/1394014117.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.851652,
     "lbl:longitude":12.304542,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"201",
+        "dk-geodk:code_qualified":"1084201",
         "eg:gisco_id":"DK_201",
         "eurostat:nuts_2021_id":"201"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"5375bacd91289a5705065651331a3c2d",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352152,
+    "wof:lastmodified":1695876713,
     "wof:name":"Allerod",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/411/9/1394014119.geojson
+++ b/data/139/401/411/9/1394014119.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.68744,
     "lbl:longitude":12.412812,
     "lbl:max_zoom":18.0,
@@ -109,9 +112,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"161",
+        "dk-geodk:code_qualified":"1084161",
         "eg:gisco_id":"DK_161",
         "eurostat:nuts_2021_id":"161"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"4da5fa492cf26ade64adecd34ed1dbad",
     "wof:hierarchy":[
@@ -129,7 +138,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352152,
+    "wof:lastmodified":1695876714,
     "wof:name":"Glostrup",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/412/1/1394014121.geojson
+++ b/data/139/401/412/1/1394014121.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":56.187683,
     "lbl:longitude":9.539104,
     "lbl:max_zoom":18.0,
@@ -196,9 +199,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"740",
+        "dk-geodk:code_qualified":"1082740",
         "eg:gisco_id":"DK_740",
         "eurostat:nuts_2021_id":"740"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f70c12cd9e5ec2f5fae1fb59c3903e72",
     "wof:hierarchy":[
@@ -216,7 +225,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352152,
+    "wof:lastmodified":1695876714,
     "wof:name":"Silkeborg",
     "wof:parent_id":85682597,
     "wof:placetype":"localadmin",

--- a/data/139/401/412/3/1394014123.geojson
+++ b/data/139/401/412/3/1394014123.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.457922,
     "lbl:longitude":11.820059,
     "lbl:max_zoom":18.0,
@@ -139,9 +142,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"329",
+        "dk-geodk:code_qualified":"1085329",
         "eg:gisco_id":"DK_329",
         "eurostat:nuts_2021_id":"329"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"ac78b9428e214e552e2156094cdd049a",
     "wof:hierarchy":[
@@ -159,7 +168,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352153,
+    "wof:lastmodified":1695876714,
     "wof:name":"Ringsted",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/412/5/1394014125.geojson
+++ b/data/139/401/412/5/1394014125.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.669518,
     "lbl:longitude":12.253765,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"169",
+        "dk-geodk:code_qualified":"1084169",
         "eg:gisco_id":"DK_169",
         "eurostat:nuts_2021_id":"169"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"33ba6f02c0d1e8036ff5cc3f093ab24b",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352153,
+    "wof:lastmodified":1695876715,
     "wof:name":"Hoje-Taastrup",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/412/7/1394014127.geojson
+++ b/data/139/401/412/7/1394014127.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.686796,
     "lbl:longitude":12.449104,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"175",
+        "dk-geodk:code_qualified":"1084175",
         "eg:gisco_id":"DK_175",
         "eurostat:nuts_2021_id":"175"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"73026667644f450c72480700a1dcaa07",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352153,
+    "wof:lastmodified":1695876715,
     "wof:name":"Rodovre",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/412/9/1394014129.geojson
+++ b/data/139/401/412/9/1394014129.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.72901,
     "lbl:longitude":12.374804,
     "lbl:max_zoom":18.0,
@@ -115,9 +118,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"151",
+        "dk-geodk:code_qualified":"1084151",
         "eg:gisco_id":"DK_151",
         "eurostat:nuts_2021_id":"151"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"e6ffc903b079f4b7dbf1c45b0a6b4b41",
     "wof:hierarchy":[
@@ -135,7 +144,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352153,
+    "wof:lastmodified":1695876715,
     "wof:name":"Ballerup",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/413/3/1394014133.geojson
+++ b/data/139/401/413/3/1394014133.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.73726,
     "lbl:longitude":8.953261,
     "lbl:max_zoom":18.0,
@@ -86,9 +89,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"530",
+        "dk-geodk:code_qualified":"1083530",
         "eg:gisco_id":"DK_530",
         "eurostat:nuts_2021_id":"530"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"5e39a745de1d4391297da63f12866540",
     "wof:hierarchy":[
@@ -107,7 +116,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352153,
+    "wof:lastmodified":1695876715,
     "wof:name":"Billund",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/413/5/1394014135.geojson
+++ b/data/139/401/413/5/1394014135.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.681397,
     "lbl:longitude":12.527481,
     "lbl:max_zoom":18.0,
@@ -175,9 +178,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"147",
+        "dk-geodk:code_qualified":"1084147",
         "eg:gisco_id":"DK_147",
         "eurostat:nuts_2021_id":"147"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"bdb009904d620dd6a17d7bfb2b3b7a47",
     "wof:hierarchy":[
@@ -195,7 +204,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352154,
+    "wof:lastmodified":1695876716,
     "wof:name":"Frederiksberg",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/413/7/1394014137.geojson
+++ b/data/139/401/413/7/1394014137.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.585043,
     "lbl:longitude":12.247322,
     "lbl:max_zoom":18.0,
@@ -97,9 +100,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"253",
+        "dk-geodk:code_qualified":"1085253",
         "eg:gisco_id":"DK_253",
         "eurostat:nuts_2021_id":"253"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"a5dc55776023b06e70f5f1eab2948287",
     "wof:hierarchy":[
@@ -117,7 +126,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352154,
+    "wof:lastmodified":1695876716,
     "wof:name":"Greve",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/413/9/1394014139.geojson
+++ b/data/139/401/413/9/1394014139.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.289158,
     "lbl:longitude":10.685365,
     "lbl:max_zoom":18.0,
@@ -113,9 +116,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"450",
+        "dk-geodk:code_qualified":"1083450",
         "eg:gisco_id":"DK_450",
         "eurostat:nuts_2021_id":"450"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"cf12a47fb411c175ba07d63339da7ed1",
     "wof:hierarchy":[
@@ -134,7 +143,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352154,
+    "wof:lastmodified":1695876716,
     "wof:name":"Nyborg",
     "wof:parent_id":85682575,
     "wof:placetype":"localadmin",

--- a/data/139/401/414/1/1394014141.geojson
+++ b/data/139/401/414/1/1394014141.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.273058,
     "lbl:longitude":12.081932,
     "lbl:max_zoom":18.0,
@@ -97,9 +100,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"320",
+        "dk-geodk:code_qualified":"1085320",
         "eg:gisco_id":"DK_320",
         "eurostat:nuts_2021_id":"320"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"9fdc104ce22d5e8029fc125c6045abaa",
     "wof:hierarchy":[
@@ -117,7 +126,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352154,
+    "wof:lastmodified":1695876717,
     "wof:name":"Faxe",
     "wof:parent_id":85682589,
     "wof:placetype":"localadmin",

--- a/data/139/401/414/3/1394014143.geojson
+++ b/data/139/401/414/3/1394014143.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.836865,
     "lbl:longitude":12.479534,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"230",
+        "dk-geodk:code_qualified":"1084230",
         "eg:gisco_id":"DK_230",
         "eurostat:nuts_2021_id":"230"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"f9c92dd186f9823860f72af101d0a6e3",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352155,
+    "wof:lastmodified":1695876718,
     "wof:name":"Rudersdal",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/414/5/1394014145.geojson
+++ b/data/139/401/414/5/1394014145.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.623326,
     "lbl:longitude":12.318957,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"183",
+        "dk-geodk:code_qualified":"1084183",
         "eg:gisco_id":"DK_183",
         "eurostat:nuts_2021_id":"183"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"16d4473f9b06fb201048315ef3bdbe6e",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352155,
+    "wof:lastmodified":1695876718,
     "wof:name":"Ishoj",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/414/7/1394014147.geojson
+++ b/data/139/401/414/7/1394014147.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.946809,
     "lbl:longitude":12.435435,
     "lbl:max_zoom":18.0,
@@ -109,9 +112,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"210",
+        "dk-geodk:code_qualified":"1084210",
         "eg:gisco_id":"DK_210",
         "eurostat:nuts_2021_id":"210"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"b7526a263388bb3a0b1cea06a318a77c",
     "wof:hierarchy":[
@@ -129,7 +138,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352155,
+    "wof:lastmodified":1695876718,
     "wof:name":"Fredensborg",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/415/1/1394014151.geojson
+++ b/data/139/401/415/1/1394014151.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.639859,
     "lbl:longitude":12.407781,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"153",
+        "dk-geodk:code_qualified":"1084153",
         "eg:gisco_id":"DK_153",
         "eurostat:nuts_2021_id":"153"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"8dc09f94b7d60b87cf3b8e902a870740",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352156,
+    "wof:lastmodified":1695876718,
     "wof:name":"Brondby",
     "wof:parent_id":85682581,
     "wof:placetype":"localadmin",

--- a/data/139/401/415/3/1394014153.geojson
+++ b/data/139/401/415/3/1394014153.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":57.454705,
     "lbl:longitude":10.030574,
     "lbl:max_zoom":18.0,
@@ -70,9 +73,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"860",
+        "dk-geodk:code_qualified":"1081860",
         "eg:gisco_id":"DK_860",
         "eurostat:nuts_2021_id":"860"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"109b629f12893f62dd68a30f21d596ec",
     "wof:hierarchy":[
@@ -90,7 +99,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352156,
+    "wof:lastmodified":1695876718,
     "wof:name":"Hjorring",
     "wof:parent_id":85682593,
     "wof:placetype":"localadmin",

--- a/data/139/401/415/5/1394014155.geojson
+++ b/data/139/401/415/5/1394014155.geojson
@@ -44,6 +44,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:latitude":55.320402,
     "lbl:longitude":15.188798,
     "lbl:max_zoom":18.0,
@@ -66,9 +69,15 @@
     "wof:belongsto":[],
     "wof:breaches":[],
     "wof:concordances":{
+        "dk-geodk:code":"411",
+        "dk-geodk:code_qualified":"1084411",
         "eg:gisco_id":"DK_411",
         "eurostat:nuts_2021_id":"411"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "dk-geodk:code_qualified"
+    ],
     "wof:country":"DK",
     "wof:geomhash":"b505d1d03890514cd77adf0d0e405eec",
     "wof:hierarchy":[
@@ -86,7 +95,7 @@
     "wof:lang_x_spoken":[
         "dan"
     ],
-    "wof:lastmodified":1684352156,
+    "wof:lastmodified":1695876719,
     "wof:name":"Christianso",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/856/331/21/85633121.geojson
+++ b/data/856/331/21/85633121.geojson
@@ -1315,6 +1315,7 @@
         "hasc:id":"DK",
         "icao:code":"OY",
         "ioc:id":"DEN",
+        "iso:code":"DK",
         "itu:id":"DNK",
         "m49:code":"208",
         "marc:id":"dk",
@@ -1327,6 +1328,7 @@
         "wd:id":"Q35",
         "wmo:id":"DN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DK",
     "wof:country_alpha3":"DNK",
     "wof:geom_alt":[
@@ -1351,7 +1353,7 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1694492249,
+    "wof:lastmodified":1695881361,
     "wof:name":"Denmark",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/331/53/85633153.geojson
+++ b/data/856/331/53/85633153.geojson
@@ -896,6 +896,7 @@
         "gn:id":2622320,
         "gp:id":23424816,
         "ioc:id":"FAR",
+        "iso:code":"FO",
         "itu:id":"FRO",
         "m49:code":"234",
         "marc:id":"fa",
@@ -904,6 +905,7 @@
         "uncrt:id":"FO",
         "wmo:id":"FA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -922,7 +924,7 @@
         }
     ],
     "wof:id":85633153,
-    "wof:lastmodified":1694639811,
+    "wof:lastmodified":1695881382,
     "wof:name":"Faroe Islands",
     "wof:parent_id":136253045,
     "wof:placetype":"dependency",

--- a/data/856/825/75/85682575.geojson
+++ b/data/856/825/75/85682575.geojson
@@ -414,17 +414,23 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:region_code":25022,
+        "dk-geodk:code":"1083",
         "eurostat:nuts_2021_id":"DK03",
         "fips:code":"DA21",
         "gn:id":6418542,
         "gp:id":28362581,
         "hasc:id":"DK.SD",
+        "iso:code":"DK-83",
         "iso:id":"DK-83",
         "unlc:id":"DK-83",
         "wd:id":"Q26061"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"DK",
-    "wof:geomhash":"85aab76441cbfa27a7e95a91a28078a9",
+    "wof:geomhash":"1b528192999e09dea92706a0b870fe30",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -441,7 +447,7 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1690874675,
+    "wof:lastmodified":1695885161,
     "wof:name":"Southern",
     "wof:parent_id":85633121,
     "wof:placetype":"region",

--- a/data/856/825/81/85682581.geojson
+++ b/data/856/825/81/85682581.geojson
@@ -396,17 +396,23 @@
     ],
     "wof:concordances":{
         "digitalenvoy:region_code":25023,
+        "dk-geodk:code":"1084",
         "eurostat:nuts_2021_id":"DK01",
         "fips:code":"DA17",
         "gn:id":6418538,
         "gp:id":28362583,
         "hasc:id":"DK.HS",
+        "iso:code":"DK-84",
         "iso:id":"DK-84",
         "unlc:id":"DK-84",
         "wd:id":"Q26073"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"DK",
-    "wof:geomhash":"05939ea846aae306fed867a334ad5da2",
+    "wof:geomhash":"57059baa04a3136790601c21bfb7506a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -423,7 +429,7 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1690874675,
+    "wof:lastmodified":1695885161,
     "wof:name":"Capital",
     "wof:parent_id":85633121,
     "wof:placetype":"region",

--- a/data/856/825/89/85682589.geojson
+++ b/data/856/825/89/85682589.geojson
@@ -369,17 +369,23 @@
     ],
     "wof:concordances":{
         "digitalenvoy:region_code":25024,
+        "dk-geodk:code":"1085",
         "eurostat:nuts_2021_id":"DK02",
         "fips:code":"DA20",
         "gn:id":6418541,
         "gp:id":28362582,
         "hasc:id":"DK.SL",
+        "iso:code":"DK-85",
         "iso:id":"DK-85",
         "unlc:id":"DK-85",
         "wd:id":"Q26589"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"DK",
-    "wof:geomhash":"1760b453e0ab8ba50f02d58cb282e4cb",
+    "wof:geomhash":"b141fad9b527101cc74817f89702a72c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -396,7 +402,7 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1690874674,
+    "wof:lastmodified":1695885161,
     "wof:name":"Zealand",
     "wof:parent_id":85633121,
     "wof:placetype":"region",

--- a/data/856/825/93/85682593.geojson
+++ b/data/856/825/93/85682593.geojson
@@ -385,17 +385,23 @@
     ],
     "wof:concordances":{
         "digitalenvoy:region_code":25020,
+        "dk-geodk:code":"1081",
         "eurostat:nuts_2021_id":"DK05",
         "fips:code":"DA19",
         "gn:id":6418540,
         "gp:id":28362579,
         "hasc:id":"DK.ND",
+        "iso:code":"DK-81",
         "iso:id":"DK-81",
         "unlc:id":"DK-81",
         "wd:id":"Q26067"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"DK",
-    "wof:geomhash":"3f0d957b88c078fc81758ee3f361896e",
+    "wof:geomhash":"6969671064a0acc17375fe8e4faa28ed",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -412,7 +418,7 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1690874674,
+    "wof:lastmodified":1695885161,
     "wof:name":"North Jutland",
     "wof:parent_id":85633121,
     "wof:placetype":"region",

--- a/data/856/825/97/85682597.geojson
+++ b/data/856/825/97/85682597.geojson
@@ -430,17 +430,23 @@
     ],
     "wof:concordances":{
         "digitalenvoy:region_code":25021,
+        "dk-geodk:code":"1082",
         "eurostat:nuts_2021_id":"DK04",
         "fips:code":"DA18",
         "gn:id":6418539,
         "gp:id":28362580,
         "hasc:id":"DK.MJ",
+        "iso:code":"DK-82",
         "iso:id":"DK-82",
         "unlc:id":"DK-82",
         "wd:id":"Q26586"
     },
+    "wof:concordances_official":"dk-geodk:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"DK",
-    "wof:geomhash":"7a7bb76e93e11b1619102c674c8cdba5",
+    "wof:geomhash":"f0629e95df4f578b5fde8a236a3dbeef",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -457,7 +463,7 @@
         "deu",
         "kal"
     ],
-    "wof:lastmodified":1690874676,
+    "wof:lastmodified":1695885161,
     "wof:name":"Central Jutland",
     "wof:parent_id":85633121,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.